### PR TITLE
feat(tools): dedicated history renderers for pi-web-access tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-02
+
+- **ADDED:** Dedicated history renderers for the four [pi-web-access](https://github.com/nicobailon/pi-web-access) tools (`web_search`, `fetch_content`, `source_check`, `get_search_content`), which previously fell through to the default renderer. Each now gets its own nerd-font icon (web / shield-check / database-search; `web_search` keeps its magnifier) and a deterministic input summary line: the `query` or up to three `queries` joined with ` · ` (longer lists truncate as `…(+N)`), the `url` or each `urls` entry on its own line, the `claim`, and `responseId` plus whichever selector is present (`query` / `queryIndex` / `url` / `urlIndex`) — instead of the default renderer's unordered first-string pick. Collapse thresholds match the default (1/1), so their characteristically long outputs (search answers, full-page markdown, check artifacts, content slices) auto-collapse with `<Tab>` expand, same as before. Tools from other extensions and all existing renderers are unaffected (#51).
+
 ## 2026-08-01
 
 - **CHANGED:** The chat history is now rendered through [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) by default (`render.engine = "render-markdown"`), giving rendered headings, list bullets, code-block chrome and links out of the box; tool output stays fenced so shell content is not misparsed as markdown. render-markdown.nvim is therefore now a dependency of the default setup (add it to your plugin spec — see the README install examples). Set `render.engine = "builtin"` to keep the previous treesitter + custom-drawing renderer. If the default engine is active but render-markdown.nvim is not installed, pi warns once and falls back to the builtin renderer, so existing setups without the plugin keep working.

--- a/README.md
+++ b/README.md
@@ -1667,7 +1667,7 @@ Successful tool calls end silently (a blank breathing line); only errors print a
 Tools come in two rendering styles:
 
 - **Inline tools** render as a single line. `read` is the canonical example — it shows `read path/to/file (42 lines)` and stays on one line even when the file is huge, because inlining the content would just be noise. Consecutive inline tool calls are grouped without blank lines between them.
-- **Full-block tools** get the multi-line indented block shown above. `bash`, `edit`, `write`, and any tool pi2.nvim doesn't have a dedicated renderer for fall into this category.
+- **Full-block tools** get the multi-line indented block shown above. `bash`, `edit`, `write`, the four [pi-web-access](https://github.com/nicobailon/pi-web-access) tools (`web_search`, `fetch_content`, `source_check`, `get_search_content`), and any tool pi2.nvim doesn't have a dedicated renderer for fall into this category.
 
 #### Auto-collapse and `<Tab>`
 
@@ -1688,6 +1688,10 @@ Built-in thresholds:
 | `read` | — | — | Always inline |
 | `edit` | unlimited | 0 | Renders the proposed diff as input; no separate output section |
 | `write` | unlimited | 0 | Same shape as `edit` for a whole-file write |
+| `web_search` | 1 | 1 | [pi-web-access](https://github.com/nicobailon/pi-web-access) — the `query`, or up to three `queries` joined with ` · ` (longer lists truncate as `…(+N)`) |
+| `fetch_content` | 1 | 1 | pi-web-access — the `url`, or each entry of `urls` on its own line |
+| `source_check` | 1 | 1 | pi-web-access — the `claim` being checked |
+| `get_search_content` | 1 | 1 | pi-web-access — `responseId` plus whichever selector is present (`query` / `queryIndex` / `url` / `urlIndex`) |
 | (unknown) | 1 | 1 | Default renderer picks the first string argument as summary |
 
 #### Status resolution

--- a/lua/pi/ui/chat/tools.lua
+++ b/lua/pi/ui/chat/tools.lua
@@ -30,6 +30,9 @@ local TOOL_ICONS = {
     glob = nf(0xF024B), -- nf-md-folder
     web_fetch = nf(0xF0593), -- nf-md-web
     web_search = nf(0xF0349), -- nf-md-magnify
+    fetch_content = nf(0xF059F), -- nf-md-web
+    source_check = nf(0xF0565), -- nf-md-shield-check
+    get_search_content = nf(0xF0866), -- nf-md-database-search
 }
 
 --- Get the nerd font icon for a tool name.
@@ -739,6 +742,20 @@ end
 
 --- Renderers ---
 
+--- Shared on_end for tools whose output is plain result text: render the
+--- extracted result text as output. Same behavior as default_renderer.on_end.
+---@param history pi.ChatHistory
+---@param result table?
+---@param insert_at integer?
+---@return integer?
+local function render_result_output(history, _, result, _, insert_at)
+    local text = extract_result_text(result)
+    if text and text ~= "" then
+        insert_at = render_output(history, text, insert_at)
+    end
+    return insert_at
+end
+
 ---@class pi.ToolRenderer
 ---@field on_start? fun(history: pi.ChatHistory, args: table?)
 ---@field on_end? fun(history: pi.ChatHistory, args: table?, result: table?, is_error: boolean?, insert_at: integer?): integer?
@@ -926,6 +943,102 @@ local renderers = {
             local path = args.path or args.file_path
             return render_diff(history, original, args.content, 0, path, insert_at)
         end,
+    },
+    -- pi-web-access extension tools: compact input summary + collapse
+    -- thresholds (long search answers / page content collapse by default);
+    -- output rendering matches default_renderer.
+    web_search = {
+        input_visible = 1,
+        output_visible = 1,
+        on_start = function(history, args)
+            if not args then
+                return
+            end
+            local query = args.query
+            if type(query) == "string" and query ~= "" then
+                render_body_line(history, query)
+                return
+            end
+            local queries = args.queries
+            if type(queries) == "table" and #queries > 0 then
+                local parts = {}
+                for i = 1, math.min(#queries, 3) do
+                    if type(queries[i]) == "string" and queries[i] ~= "" then
+                        parts[#parts + 1] = queries[i]
+                    end
+                end
+                if #parts > 0 then
+                    local line = table.concat(parts, " · ")
+                    if #queries > 3 then
+                        line = line .. " · …(+" .. (#queries - 3) .. ")"
+                    end
+                    render_body_line(history, line)
+                end
+            end
+        end,
+        on_end = render_result_output,
+    },
+    fetch_content = {
+        input_visible = 1,
+        output_visible = 1,
+        on_start = function(history, args)
+            if not args then
+                return
+            end
+            local url = args.url
+            if type(url) == "string" and url ~= "" then
+                render_body_line(history, url)
+                return
+            end
+            local urls = args.urls
+            if type(urls) == "table" then
+                for _, u in ipairs(urls) do
+                    if type(u) == "string" and u ~= "" then
+                        render_body_line(history, u)
+                    end
+                end
+            end
+        end,
+        on_end = render_result_output,
+    },
+    source_check = {
+        input_visible = 1,
+        output_visible = 1,
+        on_start = function(history, args)
+            if args and type(args.claim) == "string" and args.claim ~= "" then
+                render_body_line(history, args.claim)
+            end
+        end,
+        on_end = render_result_output,
+    },
+    get_search_content = {
+        input_visible = 1,
+        output_visible = 1,
+        on_start = function(history, args)
+            if not args then
+                return
+            end
+            local parts = {}
+            if type(args.responseId) == "string" and args.responseId ~= "" then
+                parts[#parts + 1] = args.responseId
+            end
+            if type(args.query) == "string" and args.query ~= "" then
+                parts[#parts + 1] = args.query
+            end
+            if type(args.queryIndex) == "number" then
+                parts[#parts + 1] = "queryIndex " .. args.queryIndex
+            end
+            if type(args.url) == "string" and args.url ~= "" then
+                parts[#parts + 1] = args.url
+            end
+            if type(args.urlIndex) == "number" then
+                parts[#parts + 1] = "urlIndex " .. args.urlIndex
+            end
+            if #parts > 0 then
+                render_body_line(history, table.concat(parts, " · "))
+            end
+        end,
+        on_end = render_result_output,
     },
 }
 

--- a/tests/web_access_tools_spec.lua
+++ b/tests/web_access_tools_spec.lua
@@ -1,0 +1,190 @@
+-- Dedicated history renderers for the pi-web-access extension tools
+-- (web_search, fetch_content, source_check, get_search_content):
+-- compact input summary lines, dedicated icons, and auto-collapse of their
+-- characteristically long outputs (issue #51).
+
+local Config = require("pi.config")
+local History = require("pi.ui.chat.history")
+local Tools = require("pi.ui.chat.tools")
+
+local function pump(ms)
+    vim.wait(ms or 60)
+end
+
+local function lines_of(buf)
+    return vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+end
+
+--- Rows (0-indexed) of every buffer line containing `sub` (plain match).
+local function rows_with(buf, sub)
+    local out = {}
+    for i, l in ipairs(lines_of(buf)) do
+        if l:find(sub, 1, true) then
+            out[#out + 1] = i - 1
+        end
+    end
+    return out
+end
+
+--- Live-event shaped tool result.
+local function result_text(text)
+    return { content = { { type = "text", text = text } } }
+end
+
+describe("pi-web-access tool renderers (issue #51)", function()
+    before_each(function()
+        Config.options.render = { engine = "builtin" }
+    end)
+
+    after_each(function()
+        Config.options.render = { engine = "builtin" }
+        require("pi.ui.render")._reset()
+    end)
+
+    describe("renderer lookup", function()
+        it("returns dedicated renderers with collapse thresholds", function()
+            local default = Tools.get_renderer("__no_such_tool__")
+            for _, name in ipairs({ "web_search", "fetch_content", "source_check", "get_search_content" }) do
+                local r = Tools.get_renderer(name)
+                assert.is_not(r, default, name .. " must not fall through to default_renderer")
+                assert.are.equal(1, r.input_visible)
+                assert.are.equal(1, r.output_visible)
+                assert.is_nil(r.inline)
+            end
+        end)
+
+        it("provides dedicated icons", function()
+            local generic = Config.options.labels.tool
+            assert.are.equal(vim.fn.nr2char(0xF0349, 1), Tools.get_tool_icon("web_search"))
+            assert.are.equal(vim.fn.nr2char(0xF059F, 1), Tools.get_tool_icon("fetch_content"))
+            assert.are.equal(vim.fn.nr2char(0xF0565, 1), Tools.get_tool_icon("source_check"))
+            assert.are.equal(vim.fn.nr2char(0xF0866, 1), Tools.get_tool_icon("get_search_content"))
+            assert.is_not(generic, Tools.get_tool_icon("fetch_content"))
+        end)
+    end)
+
+    describe("web_search input summary", function()
+        it("shows a single query", function()
+            local h = History.new(960)
+            h:on_tool_start("web_search", "t1", { query = "rust async" })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "rust async") == 1)
+        end)
+
+        it("joins queries with a separator", function()
+            local h = History.new(961)
+            h:on_tool_start("web_search", "t1", { queries = { "alpha", "beta" } })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "alpha · beta") == 1)
+        end)
+
+        it("truncates query lists longer than three", function()
+            local h = History.new(962)
+            h:on_tool_start("web_search", "t1", { queries = { "q1", "q2", "q3", "q4", "q5" } })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "q1 · q2 · q3 · …(+2)") == 1)
+        end)
+    end)
+
+    describe("fetch_content input summary", function()
+        it("shows a single url", function()
+            local h = History.new(963)
+            h:on_tool_start("fetch_content", "t1", { url = "https://example.com/guide" })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "https://example.com/guide") == 1)
+        end)
+
+        it("shows each url of a urls array on its own line", function()
+            local h = History.new(964)
+            h:on_tool_start("fetch_content", "t1", { urls = { "https://a.example", "https://b.example" } })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "https://a.example") == 1)
+            assert.is_true(#rows_with(h:buf(), "https://b.example") == 1)
+        end)
+    end)
+
+    describe("source_check input summary", function()
+        it("shows the claim", function()
+            local h = History.new(965)
+            h:on_tool_start("source_check", "t1", { claim = "the api supports streaming" })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "the api supports streaming") == 1)
+        end)
+    end)
+
+    describe("get_search_content input summary", function()
+        it("shows responseId with a urlIndex selector", function()
+            local h = History.new(966)
+            h:on_tool_start("get_search_content", "t1", { responseId = "abc123", urlIndex = 1 })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "abc123 · urlIndex 1") == 1)
+        end)
+
+        it("shows responseId with query and offset-free selectors", function()
+            local h = History.new(967)
+            h:on_tool_start("get_search_content", "t1", { responseId = "xyz", url = "https://c.example" })
+            pump(60)
+            assert.is_true(#rows_with(h:buf(), "xyz · https://c.example") == 1)
+        end)
+    end)
+
+    describe("auto-collapse", function()
+        it("collapses long web_search output and expands back", function()
+            local h = History.new(968)
+            h:on_tool_start("web_search", "t1", { query = "q" })
+            pump(60)
+            local out = table.concat({ "line1", "line2", "line3", "line4", "line5" }, "\n")
+            h:on_tool_end("web_search", "t1", result_text(out), false)
+            pump(120)
+            local buf = h:buf()
+            local b = h._tool_blocks["t1"]
+            assert.is_false(b.expanded, "long output must auto-collapse")
+            assert.is_true(#rows_with(buf, Tools.GLYPHS.FOLD_CLOSE) >= 1, "header shows folded glyph")
+            assert.is_true(#rows_with(buf, "…4 lines") == 1, "collapsed summary counts hidden lines")
+            assert.is_true(#rows_with(buf, "line2") == 0, "hidden output lines are not in the buffer")
+            assert.is_true(#rows_with(buf, "line5") == 1, "tail output line stays visible")
+
+            h:_set_tool_block_expanded(b, true)
+            pump(60)
+            assert.is_true(b.expanded, "expand restores the block")
+            assert.is_true(#rows_with(buf, "line2") == 1, "hidden lines reappear after expand")
+        end)
+
+        it("does not collapse short output", function()
+            local h = History.new(969)
+            h:on_tool_start("fetch_content", "t1", { url = "https://example.com" })
+            pump(60)
+            h:on_tool_end("fetch_content", "t1", result_text("ok"), false)
+            pump(120)
+            local b = h._tool_blocks["t1"]
+            assert.is_true(b.expanded, "short output stays expanded")
+            assert.is_true(#rows_with(h:buf(), "…") == 0, "no collapsed summary for short output")
+        end)
+
+        it("keeps unknown tools on the default renderer (behavior unchanged)", function()
+            local h = History.new(970)
+            h:on_tool_start("some_other_extension_tool", "t1", { query = "q" })
+            pump(60)
+            local out = table.concat({ "a1", "b2", "c3", "d4" }, "\n")
+            h:on_tool_end("some_other_extension_tool", "t1", result_text(out), false)
+            pump(120)
+            local buf = h:buf()
+            local b = h._tool_blocks["t1"]
+            -- Default renderer keeps its own 1/1 thresholds and input picking.
+            assert.is_not(b.expanded, "default renderer still collapses long output")
+            assert.is_true(#rows_with(buf, "…3 lines") == 1, "default collapsed summary")
+            assert.is_true(#rows_with(buf, "q") >= 1, "default input summary (first short string)")
+        end)
+    end)
+
+    describe("replay compatibility", function()
+        it("renders plain-string result content from replayed toolResult", function()
+            local h = History.new(971)
+            h:on_tool_start("source_check", "t1", { claim = "the sky is blue" })
+            pump(60)
+            h:on_tool_end("source_check", "t1", { content = "Status: supported" }, false)
+            pump(120)
+            assert.is_true(#rows_with(h:buf(), "Status: supported") == 1)
+        end)
+    end)
+end)


### PR DESCRIPTION
Gitea issue: https://git.yuez.me/yuez/pi2.nvim/issues/51

Dedicated history renderers + icons for the four pi-web-access tools (`web_search`, `fetch_content`, `source_check`, `get_search_content`): deterministic input summaries (query/queries, url/urls, claim, responseId+selector) instead of the default renderer's unordered first-string pick, and nerd-font icons for the three that lacked one. Collapse thresholds (1/1) and output rendering match the default renderer exactly.

Pure addition (+311/−0): no existing renderer, module, or behavior touched.

Verified: new spec 14/14, full `make test` 294 pass / 0 fail, `make style`, `make lint` (lua-language-server 3.18.2, same as CI).