### PR TITLE
fix(sessions): list sessions in tabline order, not tabpage handle order (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **CHANGED:** In `:PiSessions`, the manual refresh (drop cached names and re-fetch) moved from `r` to `R`; `r` is now rename. The `?` help overlay lists both bindings (#61).
 
+- **FIXED:** `:PiSessions` could list sessions in the wrong order — e.g. tabs 2 and 3 swapped — because the list was sorted by tabpage handle (creation order), which stops matching the tabline once a tab is created mid-list (`:tabnew` inserts after the current tab) or tabs are rearranged with `:tabmove`. The list now follows the tabline's visual order (#63).
+
 - **FIXED:** `gf` on a path in the chat crashed with `E1513: Cannot switch buffer. 'winfixbuf' is enabled` when the session list was the only non-chat window in the tab — the target-window scan did not recognize the session list filetype and never checked `winfixbuf`. π panels, the session list, and any `winfixbuf`-pinned window are now skipped; with no eligible window the file opens in a fresh split (#62).
 
 - **FIXED:** A regression from the `(unnamed)` flicker fix: session names in `:PiSessions` only appeared when a turn *ended*, so long turns kept the row on `(unnamed)` the whole time. The backend buffers session entries and flushes them to disk when the *first assistant message* completes, so the first-user-message fallback becomes readable mid-turn — unresolved names are now retried on every `message_end` (cheap: a no-op once resolved, no timers), with the `agent_end` retry kept as a backstop. Also, a `get_state` answer arriving while a fetch is in flight no longer clobbers a name that `session_info_changed` set meanwhile (#60, follow-up to #58).

--- a/lua/pi/sessions/manager.lua
+++ b/lua/pi/sessions/manager.lua
@@ -463,16 +463,28 @@ function M.get()
     return sessions[tab]
 end
 
---- List all active sessions.
+--- List all active sessions in tabline order.
+---
+--- Tabpage handles reflect creation order, not position: a tab created while
+--- tab 1 is current lands between tabs 1 and 2, and :tabmove reorders tabs
+--- without touching handles. Sorting by handle would therefore disagree with
+--- the tabline; rank by the visual order of nvim_list_tabpages() instead.
 ---@return pi.Session[]
 function M.list()
+    ---@type table<pi.TabId, integer> visual position per tab
+    local rank = {}
+    for i, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        rank[tab] = i
+    end
     ---@type pi.Session[]
     local result = {}
     for _, session in pairs(sessions) do
         result[#result + 1] = session
     end
     table.sort(result, function(a, b)
-        return a.tab < b.tab
+        -- A session whose tab was just closed can linger until the scheduled
+        -- cleanup runs; sort it last instead of crashing on a missing rank.
+        return (rank[a.tab] or math.huge) < (rank[b.tab] or math.huge)
     end)
     return result
 end

--- a/tests/sessions_list_order_spec.lua
+++ b/tests/sessions_list_order_spec.lua
@@ -1,0 +1,135 @@
+-- :PiSessions list order must follow the tabline, not tabpage handles (issue #63).
+--
+-- Tabpage handles reflect creation order: `:tabnew` from tab 1 inserts the new
+-- tab between tabs 1 and 2, and :tabmove reorders tabs without touching
+-- handles. Sessions.list() used to sort by handle, so the sessions list could
+-- disagree with the tabline (e.g. tabs 2 and 3 swapped). These specs pin the
+-- visual-order invariant. They drive the session manager against a stubbed
+-- Rpc: no real pi process, canned responses (see session_model_pin_spec.lua).
+
+local Config = require("pi.config")
+local Rpc = require("pi.rpc")
+local Sessions = require("pi.sessions.manager")
+
+Config.setup({})
+
+local real_rpc = { start = Rpc.start, stop = Rpc.stop, send = Rpc.send }
+
+local function install_stub()
+    Rpc.start = function(self)
+        self._job_id = 999
+        return true
+    end
+    Rpc.stop = function(self)
+        self._job_id = nil
+        self._pending = {}
+    end
+    Rpc.send = function(self, cmd, callback)
+        if not self._job_id then
+            return false
+        end
+        if not cmd.id then
+            cmd.id = self._tab .. ":" .. self._req_id
+            self._req_id = self._req_id + 1
+        end
+        if callback then
+            vim.schedule(function()
+                callback({ type = "response", success = true, data = {} })
+            end)
+        end
+        return true
+    end
+end
+
+local function restore_stub()
+    Rpc.start = real_rpc.start
+    Rpc.stop = real_rpc.stop
+    Rpc.send = real_rpc.send
+end
+
+--- Tabpage handles in current visual order.
+local function visual_tabs()
+    return vim.api.nvim_list_tabpages()
+end
+
+--- Tab handles of Sessions.list(), in listing order.
+local function listed_tabs()
+    local tabs = {}
+    for _, session in ipairs(Sessions.list()) do
+        tabs[#tabs + 1] = session.tab
+    end
+    return tabs
+end
+
+describe("sessions list order (issue #63)", function()
+    local start_tab
+
+    before_each(function()
+        install_stub()
+        start_tab = vim.api.nvim_get_current_tabpage()
+    end)
+
+    after_each(function()
+        -- Stop every session first, then close the tabs we created; closing
+        -- tabs with live sessions would trigger TabClosed cleanup too, so
+        -- doing sessions first keeps teardown deterministic.
+        for _, tab in ipairs(visual_tabs()) do
+            vim.api.nvim_set_current_tabpage(tab)
+            Sessions.stop()
+        end
+        for _, tab in ipairs(visual_tabs()) do
+            if tab ~= start_tab and vim.api.nvim_tabpage_is_valid(tab) then
+                vim.api.nvim_set_current_tabpage(tab)
+                vim.cmd("tabclose!")
+            end
+        end
+        vim.api.nvim_set_current_tabpage(start_tab)
+        restore_stub()
+    end)
+
+    it("lists sessions in tabline order", function()
+        Sessions.get_or_create()
+        vim.cmd("tabnew")
+        Sessions.get_or_create()
+        vim.cmd("tabnew")
+        Sessions.get_or_create()
+
+        assert.are.same(visual_tabs(), listed_tabs())
+    end)
+
+    it("follows the tabline when a new tab is inserted mid-list", function()
+        Sessions.get_or_create()
+        vim.cmd("tabnew")
+        Sessions.get_or_create()
+
+        -- A tab created from tab 1 lands between tabs 1 and 2: its handle is
+        -- the largest one, but visually it comes second. Handle-order listing
+        -- would swap it with the last tab.
+        vim.cmd("tabfirst")
+        vim.cmd("tabnew")
+        Sessions.get_or_create()
+
+        local visual = visual_tabs()
+        assert.is_true(#visual == 3, "expected three tabs")
+        -- Precondition: visual order differs from handle order, so this
+        -- scenario actually exercises the bug.
+        local by_handle = { unpack(visual) }
+        table.sort(by_handle)
+        assert.are_not.same(by_handle, visual)
+        assert.are.same(visual, listed_tabs())
+    end)
+
+    it("follows the tabline after :tabmove", function()
+        Sessions.get_or_create()
+        vim.cmd("tabnew")
+        Sessions.get_or_create()
+        vim.cmd("tabnew")
+        Sessions.get_or_create()
+
+        vim.cmd("tabfirst")
+        vim.cmd("tabnext 3")
+        vim.cmd("tabmove 0") -- move the last tab to the front
+
+        assert.are.same(visual_tabs(), listed_tabs())
+    end)
+end)


### PR DESCRIPTION
:PiSessions sorted by tabpage handle (creation order), which diverges from the tabline after mid-list `:tabnew` or `:tabmove` (reported order swap: tabs 2/3). Now ranks by `nvim_list_tabpages()` visual order. Tests: new `sessions_list_order_spec.lua` (3 cases, fail on old code, pass on fix); full `make test`/`style`/`lint` green. Issue: git.yuez.me/yuez/pi2.nvim#63