### PR TITLE
fix(history): buffer shrink no longer silently detaches auto-follow (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-20
+
+- **FIXED:** regression from the auto-follow rework (#90): when a buffer edit *shrank* the history above the parked cursor — most commonly a long tool block auto-collapsing at the end of a tool call, or bash output cleanup — the cursor-holding restore clamped to the new last line and the follow drift check misread that as user movement, silently detaching auto-follow for the rest of the turn (a thinking block completing at the bottom, or any later content, never scrolled again while the cursor sat in the prompt). Edits that move the cursor themselves now re-park the drift expectation, so only real user movement detaches (#91).
+
 ## 2026-08-19
 
 - **FIXED:** during streaming, cursor movement in the history buffer (`h`/`j`/`k`/`l`, any navigation) was effectively impossible whenever the cursor was at — or within 10 lines of — the bottom: every render event (text delta, tool update, queue/status change) snapped the cursor back to the last line, because auto-follow was decided purely by cursor proximity and escaping required moving more than 10 lines inside one 30ms flush window. Following is now explicit state mirroring the TUI: the stream pins the window to the bottom only while you are parked there; the first cursor movement away detaches — streaming keeps appending but never moves your cursor or scroll position again — and following re-attaches when you return to the very bottom (`G` / `pi.scroll_chat_history_to_bottom()`). Scrolling the history up from the prompt (`pi.scroll_chat_history("up")`) and the agent-response jumps detach too; buffer edits while detached no longer drag the cursor (#90).

--- a/lua/pi/ui/chat/history.lua
+++ b/lua/pi/ui/chat/history.lua
@@ -570,6 +570,15 @@ function History:_with_modifiable(fn)
     local ok, err = pcall(fn)
     if restore then
         pcall(vim.api.nvim_win_set_cursor, self._win, restore)
+        -- If the edit itself moved the cursor (a shrink clamps the restore
+        -- to the new last line; an insertion at the cursor position drags
+        -- it), the drift expectation must move with it: re-park the pending
+        -- cursor at the real position, otherwise _should_auto_scroll reads
+        -- our own edit as user movement and silently detaches follow (#91).
+        local now_ok, now = pcall(vim.api.nvim_win_get_cursor, self._win)
+        if now_ok and (now[1] ~= restore[1] or now[2] ~= restore[2]) then
+            self._pending_cursor = now
+        end
     end
     vim.bo[self._buf].modifiable = false
     if not ok then

--- a/tests/history_scroll_follow_spec.lua
+++ b/tests/history_scroll_follow_spec.lua
@@ -118,4 +118,53 @@ describe("history auto-follow state (issue #90)", function()
         assert.is_true(h._auto_follow)
         assert.are.equal(total(), cursor_line())
     end)
+
+    it("buffer shrink above the parked cursor does not detach follow (#91)", function()
+        for i = 1, 10 do
+            stream("prefill " .. i .. "\n")
+        end
+        assert.are.equal(total(), cursor_line())
+        local parked_pending = h._pending_cursor
+        assert.is_truthy(parked_pending)
+
+        -- What tool-block collapse / bash cleanup do in a real turn: delete
+        -- lines above the parked cursor. The restore in _with_modifiable
+        -- clamps to the new last line; the drift check must read that as
+        -- our own edit, not user movement.
+        h:_with_modifiable(function()
+            vim.api.nvim_buf_set_lines(h:buf(), 2, 8, false, {})
+        end)
+        pump(30)
+        assert.is_true(h._auto_follow, "shrink must not detach follow")
+
+        stream("post-shrink content\n")
+        assert.are.equal(total(), cursor_line(), "streaming must re-pin after a shrink")
+    end)
+
+    it("keeps following through a collapsing tool block into a thinking block (#91)", function()
+        stream("intro text\n")
+
+        -- A bash tool whose long output auto-collapses on end (shrinks the
+        -- buffer while the cursor is parked at the bottom).
+        h:on_tool_start("bash", "t-shrink", { command = "seq 1 100" })
+        pump(40)
+        local long_out = {}
+        for i = 1, 60 do
+            long_out[#long_out + 1] = "line " .. i
+        end
+        h:on_tool_end("bash", "t-shrink", table.concat(long_out, "\n"), false)
+        pump(60)
+        assert.is_true(h._auto_follow, "collapse shrink must not detach follow")
+
+        -- Thinking block lands at the bottom afterwards; the turn keeps
+        -- streaming and the view must ride the bottom.
+        h:on_thinking_start()
+        pump(40)
+        h:on_thinking_delta("thinking about the collapsed output...")
+        pump(40)
+        h:on_thinking_end()
+        pump(40)
+        stream("final answer\n")
+        assert.are.equal(total(), cursor_line(), "view must stay pinned after thinking completes")
+    end)
 end)


### PR DESCRIPTION
Regression fix for #91 (Gitea): buffer shrinks above the parked cursor (tool-block auto-collapse, bash cleanup) clamped the cursor-holding restore and the drift check misread it as user movement, silently detaching auto-follow. Re-parks the drift expectation when our own edit moves the cursor. Two regression tests; full suite + style/lint/docs-links green.