### PR TITLE
feat(sessions): resume picker opens sessions here or in a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-27
 
+- **ADDED:** `:PiResume` picker keybindings and interaction polish. With telescope.nvim installed the resume list opens as a dedicated dropdown picker (instead of the generic `vim.ui.select` one) with a fixed key-hint title: `<CR>` / `o` open the session in the current tab, `t` / `<C-t>` open it in a new tab, `<C-x>` deletes the selected session(s) (multi-select aware, matching the existing snacks behavior). Plain letters keep working once you leave insert mode; typing in the prompt filters. Without telescope nothing changes (`vim.ui.select` flow); with snacks.nvim `t`/`<C-t>` map to "open in new tab" alongside the existing `<C-x>` delete. Every backend now asks for confirmation when opening a conversation that is still live in another tab — previously a silent double-open spawned two backend processes writing the same session file. Fix: sessions.md's resume row claimed "message counts", which no resume renderer has ever shown — dropped.
+
 - **ADDED:** sessions-overview row keys `a` / `i`: open the session under the cursor and drop straight into Insert mode with the cursor appended past the very end of its prompt draft — multi-line drafts land after the last line (`A` semantics). `<CR>` / `o` keep their plain jump semantics (#94).
 
 ## 2026-08-26

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ require("pi").setup({
 | --- | --- |
 | `:Pi [layout=side\|float]` | Open or toggle the chat in the current tab |
 | `:PiContinue [layout=side\|float]` | Continue the most recent session for the current working directory |
-| `:PiResume [layout=side\|float]` | Pick and resume a past session for the current working directory |
+| `:PiResume [layout=side\|float]` | Pick and resume a past session for the current working directory — with Telescope: `<CR>`/`o` here, `t`/`<C-t>` in a new tab |
 | `:PiToggleChat` | Toggle chat visibility |
 | `:PiToggleLayout` | Switch between side and float layout |
 | `:PiAbort` | Abort the current agent operation |

--- a/doc/sessions.md
+++ b/doc/sessions.md
@@ -32,7 +32,21 @@ There are three ways to open a chat — each honors the usual `layout=side|float
 | --- | --- | --- |
 | `:Pi` | `pi.show()` / `pi.toggle()` | Open the chat. If the current tab has no session yet, starts a fresh conversation. |
 | `:PiContinue` | `pi.continue_session()` | Load the **most recent** session for the current cwd. Skips the session currently live in another tab, so you can continue a different one. |
-| `:PiResume` | `pi.resume_session()` | Open a picker listing **all past sessions for the current cwd**, with their display names, timestamps, and message counts. |
+| `:PiResume` | `pi.resume_session()` | Open a picker listing **all past sessions for the current cwd**, with their display names and timestamps. See [Resume picker](#resume-picker) for its keybindings. |
+
+### Resume picker
+
+When [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) is installed, `:PiResume` opens a dedicated picker instead of the generic `vim.ui.select` one. The keybindings are shown as a fixed hint in the picker title:
+
+| Key | Action |
+| --- | --- |
+| `<CR>` / `o` | Open the session in the **current** tab |
+| `t` / `<C-t>` | Open the session in a **new** tab |
+| `<C-x>` | Delete the selected session file(s) (multi-select aware) |
+
+`<C-t>` exists because typing in the picker prompt is filtering — plain letters (`o`, `t`) work once you leave insert mode with `<Esc>`.
+
+Other `vim.ui.select` backends keep their generic rendering; with snacks.nvim, `t` / `<C-t>` map to "open in new tab" and `<C-x>` still deletes. Whatever the backend, opening a conversation that is still live in another tab asks for confirmation first — resuming it twice would spawn two backend processes writing the same session file, so the copies would diverge.
 
 And mid-session management:
 

--- a/lua/pi/sessions/manager.lua
+++ b/lua/pi/sessions/manager.lua
@@ -21,6 +21,7 @@
 ---@field chat pi.Chat
 ---@field attention pi.SessionAttention
 ---@field pinned_model? pi.ModelRef Model chosen in this tab. Reapplied after `new_session` so model switches made in other sessions (which core persists to global settings) don't leak into this tab's next conversation.
+---@field session_file? string Backend-reported session file path (from get_state responses). Lets the resume picker detect "still open in another tab" without extra RPC round-trips.
 ---@field startup_announcements table<string, pi.StartupAnnouncement> Extension startup data (keys ending with `:startup`) shown in the system preamble. Process-level: persists across session switches.
 ---@field system_errors pi.SystemErrorEntry[]
 ---@field cwd string Working directory the session was started in (anchor for changed_files paths).
@@ -171,12 +172,24 @@ local function stash_file_tool_args(session, tool_name, tool_call_id, args)
     session._pending_file_change_args[tool_call_id] = decoded
 end
 
---- Fetch current state and update the status line.
+--- Remember the backend's current session file path from a get_state
+--- response, next to the model pin. The resume picker uses this to warn when
+--- a picked conversation is still live in another tab.
+---@param session pi.Session
+---@param state table? get_state response data
+local function capture_session_file(session, state)
+    if type(state) == "table" and type(state.sessionFile) == "string" and state.sessionFile ~= "" then
+        session.session_file = state.sessionFile
+    end
+end
+
+--- Fetch the backend state and update the status line.
 ---@param session pi.Session
 function M.refresh_state(session)
     session.rpc:send({ type = "get_state" }, function(res)
         if res.success and res.data then
             vim.schedule(function()
+                capture_session_file(session, res.data)
                 session.chat:update_state(res.data)
             end)
         end
@@ -203,6 +216,7 @@ local function refresh_state_and_pin(session)
         if res.success and res.data then
             vim.schedule(function()
                 capture_model_pin(session, res.data)
+                capture_session_file(session, res.data)
                 session.chat:update_state(res.data)
             end)
         end
@@ -985,6 +999,185 @@ local function load_session(session, session_path)
     end
 end
 
+--- Shared renderer for resume-picker rows: date + display name or first message.
+---@param session pi.SessionInfo
+---@return string
+local function format_resume_item(session)
+    local date = session.timestamp:match("^(%d%d%d%d%-%d%d%-%d%d)") or session.timestamp
+    local label = session.name or (session.first_message ~= "" and session.first_message or "(empty)")
+    return date .. "  " .. label
+end
+
+--- Find a live session in another tab backed by the given session file.
+--- Paths stay unknown until the backend's first get_state response, so a
+--- freshly spawned process may not match yet — the guard is a safety net
+--- against the common "resume what's running over there" case, not a ledger.
+---@param session_path string
+---@param exclude_tab pi.TabId? Tab whose own live copy never counts as a conflict (the reopen target).
+---@return pi.Session?
+local function find_live_elsewhere(session_path, exclude_tab)
+    for _, s in ipairs(M.list()) do
+        if s.tab ~= exclude_tab and s.rpc:is_running() and s.session_file == session_path then
+            return s
+        end
+    end
+    return nil
+end
+
+--- Open a past session picked from :PiResume: optionally move to a fresh
+--- tabpage first, create the destination tab's session when needed, then
+--- switch to `session_path`.
+---
+--- If the conversation is still live in another tab, a confirm dialog guards
+--- against spawning a second backend process writing the same session file
+--- (the two copies would diverge).
+---@param session_path string
+---@param opts? pi.SessionCreateOpts
+---@param new_tab? boolean
+local function open_resume_target(session_path, opts, new_tab)
+    local function start()
+        if new_tab then
+            vim.cmd("tabnew")
+        end
+        local session = M.get_or_create(opts)
+        if not session then
+            return
+        end
+        session.chat:show({ loading = true })
+        load_session(session, session_path)
+    end
+
+    -- For an in-place open the destination is the current tab: reopening this
+    -- tab's own live copy is the normal self-switch, so exclude it from the
+    -- conflict check. A new-tab open conflicts with any live copy.
+    local live = find_live_elsewhere(session_path, new_tab and nil or current_tab())
+    if not live then
+        start()
+        return
+    end
+    Dialog.confirm({
+        title = "Session already open",
+        message = "This conversation is still running in another tab. Opening it again spawns a second"
+            .. " process writing the same session file (they will diverge). Continue?",
+    }, function(confirmed)
+        if confirmed then
+            start()
+        end
+    end)
+end
+
+--- Open the resume list through a dedicated telescope picker.
+--- Returns false when telescope is unavailable so the caller falls back to
+--- the generic vim.ui.select flow below.
+---
+--- Keybindings (hinted in the picker title): <CR>/o open in the current tab,
+--- t/<C-t> open in a new tab, <C-x> delete the selected session(s).
+---@param items pi.SessionSelectItem[]
+---@param opts? pi.SessionCreateOpts
+---@return boolean handled
+local function open_with_telescope(items, opts)
+    local ok_telescope = pcall(require, "telescope")
+    if not ok_telescope then
+        return false
+    end
+
+    local themes = require("telescope.themes")
+    local pickers = require("telescope.pickers")
+    local finders = require("telescope.finders")
+    local conf = require("telescope.config").values
+    local actions = require("telescope.actions")
+    local action_state = require("telescope.actions.state")
+
+    ---@param item pi.SessionSelectItem
+    ---@return table telescope entry
+    local function entry_maker(item)
+        return { value = item, display = format_resume_item(item.session), ordinal = format_resume_item(item.session) }
+    end
+
+    pickers
+        .new(themes.get_dropdown({ previewer = false }), {
+            prompt_title = "Resume session",
+            results_title = " <CR>/o open · t/<C-t> new tab · <C-x> delete ",
+            finder = finders.new_table({ results = items, entry_maker = entry_maker }),
+            sorter = conf.generic_sorter(),
+            attach_mappings = function(prompt_bufnr, map)
+                local function open(new_tab)
+                    local selection = action_state.get_selected_entry(prompt_bufnr)
+                    if not selection then
+                        return
+                    end
+                    actions.close(prompt_bufnr)
+                    vim.schedule(function()
+                        open_resume_target(selection.value.file, opts, new_tab)
+                    end)
+                end
+
+                actions.select_default:replace(function()
+                    open(false)
+                end)
+                map("n", "o", function()
+                    open(false)
+                end)
+                map("n", "t", function()
+                    open(true)
+                end)
+                map("n", "<C-t>", function()
+                    open(true)
+                end)
+                map("i", "<C-t>", function()
+                    open(true)
+                end)
+
+                map({ "n", "i" }, "<C-x>", function()
+                    local targets = {} ---@type string[]
+                    for _, entry in ipairs(action_state.get_multi_selection(prompt_bufnr)) do
+                        targets[#targets + 1] = entry.value.file
+                    end
+                    if #targets == 0 then
+                        local selection = action_state.get_selected_entry(prompt_bufnr)
+                        if selection then
+                            targets[1] = selection.value.file
+                        end
+                    end
+                    if #targets == 0 then
+                        return
+                    end
+                    local msg = #targets == 1 and "Delete session?" or (("Delete %d sessions?"):format(#targets))
+                    if vim.fn.confirm(msg, "&Yes\n&No", 2) ~= 1 then
+                        return
+                    end
+                    ---@type table<string, boolean>
+                    local deleted = {}
+                    for _, path in ipairs(targets) do
+                        deleted[path] = true
+                        local ok, err = os.remove(path)
+                        if not ok then
+                            Notify.warn("Failed to delete session: " .. (err or path))
+                        end
+                    end
+                    local remaining = {}
+                    for _, item in ipairs(items) do
+                        if not deleted[item.file] then
+                            remaining[#remaining + 1] = item
+                        end
+                    end
+                    items = remaining
+                    if #remaining == 0 then
+                        actions.close(prompt_bufnr)
+                        Notify.info("No sessions remaining")
+                        return
+                    end
+                    action_state
+                        .get_current_picker(prompt_bufnr)
+                        :refresh(finders.new_table({ results = remaining, entry_maker = entry_maker }))
+                end)
+                return true
+            end,
+        })
+        :find()
+    return true
+end
+
 ---@param current_session_file? string
 ---@return string?
 local function find_continue_session_path(current_session_file)
@@ -1097,18 +1290,22 @@ function M.resume_session(opts)
         }
     end
 
+    -- Telescope gets a purpose-built picker (dedicated keybindings plus a
+    -- fixed key-hint title); every other backend keeps the generic
+    -- vim.ui.select rendering below.
+    if open_with_telescope(items, opts) then
+        return
+    end
+
     vim.ui.select(items, {
         prompt = "Resume session",
         kind = "pi-resume-session",
         -- Pass picker items with a `file` field so backends like snacks.nvim
         -- can preview the raw session file when preview is enabled. Other
         -- vim.ui.select implementations ignore extra fields and render via
-        -- `format_item`.
+        -- `format_item`. Same row rendering as the telescope picker above.
         format_item = function(item)
-            local session = item.session
-            local date = session.timestamp:match("^(%d%d%d%d%-%d%d%-%d%d)") or session.timestamp
-            local label = session.name or (session.first_message ~= "" and session.first_message or "(empty)")
-            return date .. "  " .. label
+            return format_resume_item(item.session)
         end,
         snacks = {
             -- snacks.nvim (if installed) overrides vim.ui.select with its picker.
@@ -1126,10 +1323,30 @@ function M.resume_session(opts)
                 end,
             },
             win = {
-                input = { keys = { ["<C-x>"] = { "delete_session", mode = { "i", "n" }, desc = "Delete session" } } },
-                list = { keys = { ["<C-x>"] = { "delete_session", mode = { "n" }, desc = "Delete session" } } },
+                input = {
+                    keys = {
+                        ["<C-x>"] = { "delete_session", mode = { "i", "n" }, desc = "Delete session" },
+                        ["<C-t>"] = { "resume_new_tab", mode = { "i", "n" }, desc = "Open in new tab" },
+                    },
+                },
+                list = {
+                    keys = {
+                        ["<C-x>"] = { "delete_session", mode = { "n" }, desc = "Delete session" },
+                        ["<C-t>"] = { "resume_new_tab", mode = { "n" }, desc = "Open in new tab" },
+                    },
+                },
             },
             actions = {
+                resume_new_tab = function(picker)
+                    local selected = picker:selected({ fallback = true })
+                    if #selected == 0 then
+                        return
+                    end
+                    picker:close()
+                    vim.schedule(function()
+                        open_resume_target(selected[1].item.file, opts, true)
+                    end)
+                end,
                 delete_session = function(picker)
                     local selected = picker:selected({ fallback = true })
                     if #selected == 0 then
@@ -1169,12 +1386,7 @@ function M.resume_session(opts)
         if not item then
             return
         end
-        local session = M.get_or_create(opts)
-        if not session then
-            return
-        end
-        session.chat:show({ loading = true })
-        load_session(session, item.session.path)
+        open_resume_target(item.file, opts)
     end)
 end
 

--- a/lua/pi/sessions/manager.lua
+++ b/lua/pi/sessions/manager.lua
@@ -1094,86 +1094,94 @@ local function open_with_telescope(items, opts)
         return { value = item, display = format_resume_item(item.session), ordinal = format_resume_item(item.session) }
     end
 
+    -- NOTE: pickers.new(opts, defaults) lets `opts` (this first table) win on
+    -- key conflicts, and get_dropdown pins results_title = false. The titles
+    -- must live in that same first table or the key hint gets clobbered.
     pickers
-        .new(themes.get_dropdown({ previewer = false }), {
-            prompt_title = "Resume session",
-            results_title = " <CR>/o open · t/<C-t> new tab · <C-x> delete ",
-            finder = finders.new_table({ results = items, entry_maker = entry_maker }),
-            sorter = conf.generic_sorter(),
-            attach_mappings = function(prompt_bufnr, map)
-                local function open(new_tab)
-                    local selection = action_state.get_selected_entry(prompt_bufnr)
-                    if not selection then
-                        return
-                    end
-                    actions.close(prompt_bufnr)
-                    vim.schedule(function()
-                        open_resume_target(selection.value.file, opts, new_tab)
-                    end)
-                end
-
-                actions.select_default:replace(function()
-                    open(false)
-                end)
-                map("n", "o", function()
-                    open(false)
-                end)
-                map("n", "t", function()
-                    open(true)
-                end)
-                map("n", "<C-t>", function()
-                    open(true)
-                end)
-                map("i", "<C-t>", function()
-                    open(true)
-                end)
-
-                map({ "n", "i" }, "<C-x>", function()
-                    local targets = {} ---@type string[]
-                    for _, entry in ipairs(action_state.get_multi_selection(prompt_bufnr)) do
-                        targets[#targets + 1] = entry.value.file
-                    end
-                    if #targets == 0 then
+        .new(
+            themes.get_dropdown({
+                previewer = false,
+                prompt_title = "Resume session",
+                results_title = " <CR>/o open · t/<C-t> new tab · <C-x> delete ",
+            }),
+            {
+                finder = finders.new_table({ results = items, entry_maker = entry_maker }),
+                sorter = conf.generic_sorter(),
+                attach_mappings = function(prompt_bufnr, map)
+                    local function open(new_tab)
                         local selection = action_state.get_selected_entry(prompt_bufnr)
-                        if selection then
-                            targets[1] = selection.value.file
+                        if not selection then
+                            return
                         end
-                    end
-                    if #targets == 0 then
-                        return
-                    end
-                    local msg = #targets == 1 and "Delete session?" or (("Delete %d sessions?"):format(#targets))
-                    if vim.fn.confirm(msg, "&Yes\n&No", 2) ~= 1 then
-                        return
-                    end
-                    ---@type table<string, boolean>
-                    local deleted = {}
-                    for _, path in ipairs(targets) do
-                        deleted[path] = true
-                        local ok, err = os.remove(path)
-                        if not ok then
-                            Notify.warn("Failed to delete session: " .. (err or path))
-                        end
-                    end
-                    local remaining = {}
-                    for _, item in ipairs(items) do
-                        if not deleted[item.file] then
-                            remaining[#remaining + 1] = item
-                        end
-                    end
-                    items = remaining
-                    if #remaining == 0 then
                         actions.close(prompt_bufnr)
-                        Notify.info("No sessions remaining")
-                        return
+                        vim.schedule(function()
+                            open_resume_target(selection.value.file, opts, new_tab)
+                        end)
                     end
-                    action_state
-                        .get_current_picker(prompt_bufnr)
-                        :refresh(finders.new_table({ results = remaining, entry_maker = entry_maker }))
-                end)
-                return true
-            end,
-        })
+
+                    actions.select_default:replace(function()
+                        open(false)
+                    end)
+                    map("n", "o", function()
+                        open(false)
+                    end)
+                    map("n", "t", function()
+                        open(true)
+                    end)
+                    map("n", "<C-t>", function()
+                        open(true)
+                    end)
+                    map("i", "<C-t>", function()
+                        open(true)
+                    end)
+
+                    map({ "n", "i" }, "<C-x>", function()
+                        local targets = {} ---@type string[]
+                        for _, entry in ipairs(action_state.get_multi_selection(prompt_bufnr)) do
+                            targets[#targets + 1] = entry.value.file
+                        end
+                        if #targets == 0 then
+                            local selection = action_state.get_selected_entry(prompt_bufnr)
+                            if selection then
+                                targets[1] = selection.value.file
+                            end
+                        end
+                        if #targets == 0 then
+                            return
+                        end
+                        local msg = #targets == 1 and "Delete session?" or (("Delete %d sessions?"):format(#targets))
+                        if vim.fn.confirm(msg, "&Yes\n&No", 2) ~= 1 then
+                            return
+                        end
+                        ---@type table<string, boolean>
+                        local deleted = {}
+                        for _, path in ipairs(targets) do
+                            deleted[path] = true
+                            local ok, err = os.remove(path)
+                            if not ok then
+                                Notify.warn("Failed to delete session: " .. (err or path))
+                            end
+                        end
+                        local remaining = {}
+                        for _, item in ipairs(items) do
+                            if not deleted[item.file] then
+                                remaining[#remaining + 1] = item
+                            end
+                        end
+                        items = remaining
+                        if #remaining == 0 then
+                            actions.close(prompt_bufnr)
+                            Notify.info("No sessions remaining")
+                            return
+                        end
+                        action_state
+                            .get_current_picker(prompt_bufnr)
+                            :refresh(finders.new_table({ results = remaining, entry_maker = entry_maker }))
+                    end)
+                    return true
+                end,
+            }
+        )
         :find()
     return true
 end

--- a/tests/resume_picker_spec.lua
+++ b/tests/resume_picker_spec.lua
@@ -1,0 +1,496 @@
+-- :PiResume picker interactions — layered UI over the same opening logic.
+--
+-- With telescope installed the resume list gets a purpose-built picker:
+-- <CR>/o open in the current tab, t/<C-t> open in a new tab, <C-x> delete,
+-- plus a fixed key-hint title. Without telescope it falls back to the
+-- generic vim.ui.select flow (unchanged behavior); there the snacks backend
+-- customization additionally maps <C-t>. Opening a conversation that is
+-- still live in another tab asks for confirmation first (two processes would
+-- write one session file).
+--
+-- These specs drive the session manager against a stubbed Rpc with canned
+-- responses — no real pi process, no real telescope (a fake module tree is
+-- injected into package.loaded for the telescope-branch specs).
+
+local Config = require("pi.config")
+local Rpc = require("pi.rpc")
+local Sessions = require("pi.sessions.manager")
+local History = require("pi.sessions.history")
+local Pi = require("pi")
+
+Config.setup({})
+Pi.setup({})
+
+local T_TARGET = "/tmp/pi-resume-spec/target.jsonl"
+local T_OTHER = "/tmp/pi-resume-spec/other.jsonl"
+
+--- Fabricated history listing (history.list scans disk; stubbed here).
+local fake_sessions_list
+
+local real_rpc = { start = Rpc.start, stop = Rpc.stop, send = Rpc.send }
+local real_history_list = History.list
+local real_notify = vim.notify
+local real_select = vim.ui.select
+
+--- Commands sent through the stub, in order.
+local sent = {}
+--- type -> fun(cmd): pi.RpcEvent; nil responder = never answered.
+local responders = {}
+--- vim.notify spy records.
+local notes = {}
+--- vim.ui.select spy: calls in order plus a one-shot answer() for the
+--- most recent picker.
+local select_spy
+
+local function install_stub()
+    sent = {}
+    responders = {}
+    notes = {}
+    select_spy = { calls = {}, pending = nil }
+
+    Rpc.start = function(self)
+        self._job_id = 999
+        return true
+    end
+    Rpc.stop = function(self)
+        self._job_id = nil
+        self._pending = {}
+    end
+    Rpc.send = function(self, cmd, callback)
+        if not self._job_id then
+            return false
+        end
+        if not cmd.id then
+            cmd.id = self._tab .. ":" .. self._req_id
+            self._req_id = self._req_id + 1
+        end
+        sent[#sent + 1] = vim.deepcopy(cmd)
+        local responder = responders[cmd.type]
+        if callback and responder then
+            local res = responder(cmd)
+            vim.schedule(function()
+                callback(res)
+            end)
+        end
+        return true
+    end
+
+    vim.notify = function(msg, level)
+        notes[#notes + 1] = { msg = msg, level = level }
+    end
+
+    vim.ui.select = function(items, opts, on_choice)
+        select_spy.calls[#select_spy.calls + 1] = { items = items, opts = opts, on_choice = on_choice }
+        select_spy.pending = on_choice
+    end
+
+    responders.get_commands = function()
+        return { type = "response", success = true, data = { commands = {} } }
+    end
+    responders.get_state = function()
+        return {
+            type = "response",
+            success = true,
+            data = { model = { provider = "test", id = "m" }, autoCompactionEnabled = false, sessionFile = T_OTHER },
+        }
+    end
+    responders.switch_session = function(_cmd)
+        return { type = "response", success = true, data = { cancelled = false } }
+    end
+    responders.get_messages = function()
+        return {
+            type = "response",
+            success = true,
+            data = {
+                messages = {
+                    { role = "user", content = "original ask" },
+                    { role = "assistant", content = "original answer" },
+                },
+            },
+        }
+    end
+end
+
+--- Drop into a pristine single-tab state; sweep stale sessions afterwards.
+local function settle_tabs(first_tab)
+    if vim.api.nvim_get_current_tabpage() ~= first_tab then
+        vim.api.nvim_set_current_tabpage(first_tab)
+    end
+    vim.cmd("silent! tabonly!")
+    Sessions.cleanup()
+    Sessions.stop()
+end
+
+local function restore_stub(first_tab)
+    settle_tabs(first_tab)
+    Rpc.start = real_rpc.start
+    Rpc.stop = real_rpc.stop
+    Rpc.send = real_rpc.send
+    History.list = real_history_list
+    vim.notify = real_notify
+    vim.ui.select = real_select
+end
+
+--- Wait until fn() is truthy; fail the spec with `what` otherwise.
+local function wait_or_fail(fn, what)
+    assert(vim.wait(3000, fn, 10), what)
+end
+
+--- First command of `type` sent after index `from` (0 = from start).
+---@return table? cmd
+---@return integer idx
+local function find_after(from, type)
+    for i = from + 1, #sent do
+        if sent[i].type == type then
+            return sent[i], i
+        end
+    end
+    return nil, #sent
+end
+
+--- Most recent vim.ui.select call whose opts.kind matches.
+---@return table?
+local function last_select_call(kind)
+    for i = #select_spy.calls, 1, -1 do
+        if select_spy.calls[i].opts.kind == kind then
+            return select_spy.calls[i]
+        end
+    end
+    return nil
+end
+
+--- Create the fake telescope module tree and return recording state.
+local function install_fake_telescope()
+    ---@class FakeTeleState
+    local state = { new_cfgs = {}, maps = {}, entry = nil }
+
+    package.loaded["telescope"] = {}
+    package.loaded["telescope.themes"] = {
+        get_dropdown = function(opts)
+            return opts or {}
+        end,
+    }
+    package.loaded["telescope.pickers"] = {
+        new = function(_, cfg)
+            state.new_cfgs[#state.new_cfgs + 1] = cfg
+            return { find = function() end }
+        end,
+    }
+    package.loaded["telescope.finders"] = {
+        new_table = function(tbl)
+            return tbl
+        end,
+    }
+    package.loaded["telescope.config"] = {
+        values = {
+            generic_sorter = function()
+                return "sorter"
+            end,
+        },
+    }
+    package.loaded["telescope.actions"] = {
+        -- Called as a method: replace(self, replacement_fn).
+        select_default = {
+            replace = function(_self, fn)
+                state.select_default = fn
+            end,
+        },
+        close = function(bufnr)
+            state.closed_bufnr = bufnr
+        end,
+    }
+    package.loaded["telescope.actions.state"] = {
+        get_selected_entry = function(_bufnr)
+            return state.entry
+        end,
+        get_multi_selection = function(_bufnr)
+            return {}
+        end,
+        get_current_picker = function(_bufnr)
+            return {
+                refresh = function(_, finder)
+                    state.refreshed_finder = finder
+                end,
+            }
+        end,
+    }
+    return state
+end
+
+local FAKE_MODULES = {
+    "telescope",
+    "telescope.themes",
+    "telescope.pickers",
+    "telescope.finders",
+    "telescope.config",
+    "telescope.actions",
+    "telescope.actions.state",
+}
+
+local function remove_fake_telescope()
+    for _, name in ipairs(FAKE_MODULES) do
+        package.loaded[name] = nil
+    end
+end
+
+describe("pi resume picker", function()
+    local first_tab
+
+    before_each(function()
+        install_stub()
+        History.list = function()
+            return fake_sessions_list
+                or {
+                    {
+                        path = T_TARGET,
+                        name = nil,
+                        timestamp = "2025-06-01T10:00:00.000Z",
+                        first_message = "original ask",
+                    },
+                    {
+                        path = T_OTHER,
+                        name = "named session",
+                        timestamp = "2025-06-02T11:00:00.000Z",
+                        first_message = "",
+                    },
+                }
+        end
+        fake_sessions_list = nil
+        first_tab = vim.api.nvim_get_current_tabpage()
+    end)
+
+    after_each(function()
+        remove_fake_telescope()
+        restore_stub(first_tab)
+    end)
+
+    it("falls back to vim.ui.select without telescope and carries item/file data", function()
+        Sessions.resume_session()
+
+        assert.is_not_nil(select_spy.pending)
+        local call = last_select_call("pi-resume-session")
+        assert.is_not_nil(call)
+        assert.equals("Resume session", call.opts.prompt)
+        assert.equals(2, #call.items)
+        assert.equals(T_TARGET, call.items[1].file)
+        assert.equals("named session", call.items[2].session.name)
+
+        -- Row rendering stays date + label.
+        local label = call.opts.format_item(call.items[1])
+        assert.truthy(label:find("2025%-06%-01  original ask", 1, false))
+        local label2 = call.opts.format_item(call.items[2])
+        assert.truthy(label2:find("2025%-06%-02  named session", 1, false))
+    end)
+
+    it("opening from the fallback picker loads the session in the current tab", function()
+        local before_tabs = #vim.api.nvim_list_tabpages()
+
+        Sessions.resume_session()
+        local call = last_select_call("pi-resume-session")
+        call.on_choice(call.items[1])
+
+        wait_or_fail(function()
+            local switch, sidx = find_after(0, "switch_session")
+            return switch ~= nil and sidx ~= nil and find_after(sidx, "get_messages") ~= nil
+        end, "switch_session was not sent")
+
+        local switch, sidx = find_after(0, "switch_session")
+        assert.equals(T_TARGET, switch.sessionPath)
+        assert.not_nil(find_after(sidx, "get_messages"))
+        assert.equals(before_tabs, #vim.api.nvim_list_tabpages())
+    end)
+
+    it("snacks action resume_new_tab opens the picked session in a new tab", function()
+        local before_tabs = #vim.api.nvim_list_tabpages()
+
+        Sessions.resume_session()
+        local call = last_select_call("pi-resume-session")
+        assert.is_not_nil(call.opts.snacks and call.opts.snacks.actions.resume_new_tab)
+
+        local closed = false
+        call.opts.snacks.actions.resume_new_tab({
+            selected = function()
+                return { { item = call.items[1] } }
+            end,
+            close = function()
+                closed = true
+            end,
+        })
+
+        wait_or_fail(function()
+            return #vim.api.nvim_list_tabpages() == before_tabs + 1
+        end, "new tab was not opened")
+        assert.is_true(closed)
+
+        wait_or_fail(function()
+            local sess = Sessions.get()
+            return sess ~= nil and find_after(0, "switch_session") ~= nil
+        end, "session was not loaded into the new tab")
+
+        local switch = find_after(0, "switch_session")
+        assert.equals(T_TARGET, switch.sessionPath)
+        -- The live session belongs to the fresh tabpage, not the original one.
+        assert.not_equals(first_tab, Sessions.get().tab)
+    end)
+
+    it("reopening a conversation that lives in another tab asks for confirmation and honours decline", function()
+        -- Tab 2 hosts the very conversation being picked.
+        vim.cmd("tabnew")
+        local elsewhere = Sessions.get_or_create()
+        assert.is_not_nil(elsewhere)
+        wait_or_fail(function()
+            return elsewhere.session_file == T_OTHER
+        end, "live session did not capture its backend file")
+        vim.cmd("tabprevious")
+        assert.equals(first_tab, vim.api.nvim_get_current_tabpage())
+
+        Sessions.resume_session()
+        local call = last_select_call("pi-resume-session")
+        call.on_choice(call.items[2]) -- T_OTHER, live in tab 2
+
+        wait_or_fail(function()
+            return last_select_call("pi-confirm") ~= nil
+        end, "confirmation dialog was not shown")
+
+        select_spy.pending("No")
+        assert.equals(nil, find_after(0, "switch_session"), "declined open must not switch sessions")
+    end)
+
+    it("confirming the duplicate-open warning switches in place", function()
+        vim.cmd("tabnew")
+        local elsewhere = Sessions.get_or_create()
+        assert.is_not_nil(elsewhere)
+        wait_or_fail(function()
+            return elsewhere.session_file == T_OTHER
+        end, "live session did not capture its backend file")
+        vim.cmd("tabprevious")
+
+        Sessions.resume_session()
+        local call = last_select_call("pi-resume-session")
+        call.on_choice(call.items[2]) -- T_OTHER, live in tab 2
+
+        wait_or_fail(function()
+            return last_select_call("pi-confirm") ~= nil
+        end, "confirmation dialog was not shown")
+        select_spy.pending("Yes")
+
+        wait_or_fail(function()
+            return find_after(0, "switch_session") ~= nil
+        end, "confirmed open must switch sessions")
+        local switch = find_after(0, "switch_session")
+        assert.equals(T_OTHER, switch.sessionPath)
+    end)
+
+    it("picking a session with no live copy elsewhere skips the confirmation entirely", function()
+        vim.cmd("tabnew")
+        local elsewhere = Sessions.get_or_create()
+        assert.is_not_nil(elsewhere)
+        wait_or_fail(function()
+            return elsewhere.session_file == T_OTHER
+        end, "live session did not capture its backend file")
+        vim.cmd("tabprevious")
+
+        Sessions.resume_session()
+        local call = last_select_call("pi-resume-session")
+        call.on_choice(call.items[1]) -- T_TARGET: nowhere live
+
+        wait_or_fail(function()
+            return find_after(0, "switch_session") ~= nil
+        end, "uncontended open must go straight through")
+        assert.is_nil(last_select_call("pi-confirm"), "no confirmation expected for a non-live session")
+    end)
+
+    describe("with telescope installed", function()
+        local tele
+
+        before_each(function()
+            tele = install_fake_telescope()
+        end)
+
+        it("builds a dedicated picker instead of calling vim.ui.select", function()
+            Sessions.resume_session()
+
+            assert.equals(1, #tele.new_cfgs)
+            assert.equals(nil, select_spy.pending, "fallback vim.ui.select must not be used")
+
+            local cfg = tele.new_cfgs[1]
+            assert.equals("Resume session", cfg.prompt_title)
+            assert.truthy(cfg.results_title:find("<CR>/o open", 1, true))
+            assert.truthy(cfg.results_title:find("t/<C%-t> new tab", 1, false))
+            assert.truthy(cfg.results_title:find("<C%-x> delete", 1, false))
+            assert.equals(2, #cfg.finder.results)
+            assert.equals(T_TARGET, cfg.finder.results[1].file)
+        end)
+
+        it("maps o/t/<C-t> and opens rows via select_default and <C-t>", function()
+            local before_tabs = #vim.api.nvim_list_tabpages()
+
+            Sessions.resume_session()
+            local cfg = tele.new_cfgs[1]
+            cfg.attach_mappings(7, function(_modes, lhs, fn)
+                tele.maps[lhs] = fn
+            end)
+
+            -- select_default -> current tab.
+            tele.entry = { value = cfg.finder.results[1] }
+            tele.select_default()
+            wait_or_fail(function()
+                local switch, sidx = find_after(0, "switch_session")
+                return switch ~= nil and sidx ~= nil and find_after(sidx, "get_messages") ~= nil
+            end, "select_default did not open in place")
+            local switch = find_after(0, "switch_session")
+            assert.equals(T_TARGET, switch.sessionPath)
+            assert.equals(before_tabs, #vim.api.nvim_list_tabpages())
+            assert.equals(7, tele.closed_bufnr)
+
+            -- normal-mode o -> current tab too.
+            install_stub()
+            local base_o = #sent
+            Sessions.resume_session()
+            cfg = tele.new_cfgs[2]
+            cfg.attach_mappings(8, function(_modes, lhs, fn)
+                tele.maps[lhs] = fn
+            end)
+            tele.entry = { value = cfg.finder.results[1] }
+            local o_target_path = tele.entry.value.file
+            assert.equals(T_TARGET, o_target_path)
+            tele.maps["o"]()
+            wait_or_fail(function()
+                return find_after(base_o, "switch_session") ~= nil
+            end, "o did not open in place")
+
+            -- normal-mode t -> new tab.
+            local tabs_before_t = #vim.api.nvim_list_tabpages()
+            install_stub()
+            local base_t = #sent
+            Sessions.resume_session()
+            cfg = tele.new_cfgs[3]
+            cfg.attach_mappings(9, function(_modes, lhs, fn)
+                tele.maps[lhs] = fn
+            end)
+            tele.entry = { value = cfg.finder.results[1] }
+            tele.maps["t"]()
+
+            wait_or_fail(function()
+                return #vim.api.nvim_list_tabpages() == tabs_before_t + 1
+                    and find_after(base_t, "switch_session") ~= nil
+            end, "t did not open a new tab")
+
+            -- <C-t> (bound in insert mode, n mode is the same opener) -> new tab.
+            local tabs_before_ct = #vim.api.nvim_list_tabpages()
+            install_stub()
+            local base_ct = #sent
+            Sessions.resume_session()
+            cfg = tele.new_cfgs[4]
+            cfg.attach_mappings(10, function(_modes, lhs, fn)
+                tele.maps[lhs] = fn
+            end)
+            tele.entry = { value = cfg.finder.results[1] }
+            tele.maps["<C-t>"]()
+            wait_or_fail(function()
+                return #vim.api.nvim_list_tabpages() == tabs_before_ct + 1
+                    and find_after(base_ct, "switch_session") ~= nil
+            end, "<C-t> did not open a new tab")
+        end)
+    end)
+end)

--- a/tests/resume_picker_spec.lua
+++ b/tests/resume_picker_spec.lua
@@ -162,11 +162,14 @@ end
 --- Create the fake telescope module tree and return recording state.
 local function install_fake_telescope()
     ---@class FakeTeleState
-    local state = { new_cfgs = {}, maps = {}, entry = nil }
+    local state = { new_cfgs = {}, maps = {}, themes = {}, entry = nil }
 
     package.loaded["telescope"] = {}
     package.loaded["telescope.themes"] = {
+        -- Record the theme input: pickers.new(opts, defaults) gives `opts`
+        -- precedence, so the titles passed here are the ones telescope uses.
         get_dropdown = function(opts)
+            state.themes[#state.themes + 1] = opts
             return opts or {}
         end,
     }
@@ -413,11 +416,17 @@ describe("pi resume picker", function()
             assert.equals(1, #tele.new_cfgs)
             assert.equals(nil, select_spy.pending, "fallback vim.ui.select must not be used")
 
+            -- Titles live in the theme table (first pickers.new arg), which
+            -- wins over get_dropdown's own results_title = false.
+            local theme = tele.themes[1]
+            assert.is_not_nil(theme)
+            assert.equals("Resume session", theme.prompt_title)
+            assert.truthy(theme.results_title:find("<CR>/o open", 1, true))
+            assert.truthy(theme.results_title:find("t/<C%-t> new tab", 1, false))
+            assert.truthy(theme.results_title:find("<C%-x> delete", 1, false))
+
             local cfg = tele.new_cfgs[1]
-            assert.equals("Resume session", cfg.prompt_title)
-            assert.truthy(cfg.results_title:find("<CR>/o open", 1, true))
-            assert.truthy(cfg.results_title:find("t/<C%-t> new tab", 1, false))
-            assert.truthy(cfg.results_title:find("<C%-x> delete", 1, false))
+            assert.equals(false, theme.previewer)
             assert.equals(2, #cfg.finder.results)
             assert.equals(T_TARGET, cfg.finder.results[1].file)
         end)


### PR DESCRIPTION
Closes #95 (interactive feature request).

Adds a dedicated Telescope dropdown for  with fixed key-hint titles, new-tab keys, and a guard against opening a session that is already live in another tab. Falls back to the existing generic  flow when Telescope is unavailable.